### PR TITLE
fix: generate _: unknown type for empty request types

### DIFF
--- a/packages/core/src/printMethod.ts
+++ b/packages/core/src/printMethod.ts
@@ -32,7 +32,7 @@ export function printMethod(
 
   const strs = item.params.map((param) => {
     const requestType =
-      param.requestType === EMPTY ? '' : `params: ${param.requestType}`;
+      param.requestType === EMPTY ? '_: unknown' : `params: ${param.requestType}`;
     const responseType =
       param.responseType === EMPTY ? '{}' : param.responseType;
 


### PR DESCRIPTION
Even though `google.protobuf.Empty` defined in proto file, Javascript proto implementation requests a parameter. `null` or empty object `{}` or probably anything is accepted. But throws an error if no parameter is passed:

```
Error: Incorrect arguments passed
```